### PR TITLE
.UPDATE nomad and consul version

### DIFF
--- a/modules/ami2/nomad-consul-docker-ecr.json
+++ b/modules/ami2/nomad-consul-docker-ecr.json
@@ -1,9 +1,9 @@
 {
   "min_packer_version": "0.12.0",
   "variables": {
-    "nomad_version": "0.8.4",
-    "consul_module_version": "v0.3.5",
-    "consul_version": "1.2.1",
+    "nomad_version": "0.8.5",
+    "consul_module_version": "v0.3.10",
+    "consul_version": "1.2.3",
     "aws_account_id": "",
     "aws_region": "eu-central-1",
     "ami_regions": "eu-central-1,us-east-2"


### PR DESCRIPTION
The terraform-aws-consul modul was updated the last compatible version.
A newer version 0.4.0 is available but might introduce incompatible changes.