### PR TITLE
F/41 update to consul 044

### DIFF
--- a/modules/ami2/README.md
+++ b/modules/ami2/README.md
@@ -1,11 +1,32 @@
 # Overview
-* [ ] TODO: Explaining the available AMIs.
+
+- [ ] TODO: Explaining the available AMIs.
 
 # Amazon Linux 2
+
 https://aws.amazon.com/de/amazon-linux-2/release-notes/
 
-* Nomad
-* Consul
-* Docker
-* AWS ECR plugin
-* privileged mode activated
+- Nomad
+- Consul
+- Docker
+- AWS ECR plugin
+- privileged mode activated
+
+## Create the Machine Image
+
+### Prepare AWS Credentials
+
+As described at [Authentication Packer](https://www.packer.io/docs/builders/amazon.html#authentication) you can use static, evironment variables or shared credentials.
+
+```bash
+# environment variables
+export AWS_ACCESS_KEY_ID="anaccesskey"
+export AWS_SECRET_ACCESS_KEY="asecretkey"
+export AWS_DEFAULT_REGION="us-west-2"
+```
+
+### Build the AMI using Packer
+
+```bash
+packer build nomad-consul-docker-ecr.json
+```

--- a/modules/ami2/nomad-consul-docker-ecr.json
+++ b/modules/ami2/nomad-consul-docker-ecr.json
@@ -2,7 +2,7 @@
   "min_packer_version": "0.12.0",
   "variables": {
     "nomad_version": "0.8.6",
-    "consul_module_version": "v0.3.10",
+    "consul_module_version": "v0.4.4",
     "consul_version": "1.3.1",
     "aws_account_id": "",
     "aws_region": "eu-central-1",
@@ -25,24 +25,18 @@
           "block-device-mapping.volume-type": "gp2",
           "root-device-type": "ebs"
         },
-        "owners": [
-          "amazon"
-        ],
+        "owners": ["amazon"],
         "most_recent": true
       },
       "ssh_username": "ec2-user",
-      "ami_users": [
-        "{{user `aws_account_id`}}"
-      ]
+      "ami_users": ["{{user `aws_account_id`}}"]
     }
   ],
   "provisioners": [
     {
       "type": "shell",
       "script": "{{template_dir}}/setup_amazon-linux.sh",
-      "only": [
-        "amazon-linux-ami2"
-      ]
+      "only": ["amazon-linux-ami2"]
     },
     {
       "type": "file",
@@ -72,9 +66,7 @@
     },
     {
       "type": "shell",
-      "inline": [
-        "mkdir -p ~/.docker"
-      ]
+      "inline": ["mkdir -p ~/.docker"]
     },
     {
       "type": "file",

--- a/modules/ami2/nomad-consul-docker-ecr.json
+++ b/modules/ami2/nomad-consul-docker-ecr.json
@@ -6,7 +6,7 @@
     "consul_version": "1.3.1",
     "aws_account_id": "",
     "aws_region": "eu-central-1",
-    "ami_regions": "eu-central-1,us-east-2"
+    "ami_regions": "eu-central-1,us-east-1"
   },
   "builders": [
     {

--- a/modules/ami2/setup_amazon-linux.sh
+++ b/modules/ami2/setup_amazon-linux.sh
@@ -7,7 +7,7 @@ echo "[INFO] [${SCRIPT}] Setup git"
 sudo yum install -y git
 
 echo "[INFO] [${SCRIPT}] Setup docker"
-sudo yum install -y docker
+sudo amazon-linux-extras install docker
 sudo systemctl enable docker
 sudo usermod -a -G docker ec2-user
 

--- a/modules/consul/main.tf
+++ b/modules/consul/main.tf
@@ -8,7 +8,7 @@ terraform {
 # DEPLOY THE CONSUL SERVER NODES
 # ---------------------------------------------------------------------------------------------------------------------
 module "consul_servers" {
-  source = "git::https://github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.3.5"
+  source = "git::https://github.com/hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.4.4"
 
   cluster_name  = "${var.cluster_tag_value}"
   cluster_size  = "${var.num_servers}"
@@ -26,8 +26,9 @@ module "consul_servers" {
 
   allowed_ssh_cidr_blocks = "${var.allowed_ssh_cidr_blocks}"
 
-  allowed_inbound_cidr_blocks = ["0.0.0.0/32"]
-  ssh_key_name                = "${var.ssh_key_name}"
+  allowed_inbound_cidr_blocks          = []
+  allowed_inbound_security_group_count = 0
+  ssh_key_name                         = "${var.ssh_key_name}"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/consul/sg.tf
+++ b/modules/consul/sg.tf
@@ -12,35 +12,7 @@ data "aws_security_group" "consul_sg" {
 # HTTP API (Default 8500). This is used by clients to talk to the HTTP API. TCP only.
 # DNS Interface (Default 8600). Used to resolve DNS queries. TCP and UDP.
 
-# [server>server] Serf LAN and WAN, TCP
-resource "aws_security_group_rule" "sgr_srv_2_srv_serf_wan_lan_tcp" {
-  type                     = "ingress"
-  description              = "ig tcp (serf: wan/lan)"
-  from_port                = 8301
-  to_port                  = 8302
-  protocol                 = "tcp"
-  source_security_group_id = "${data.aws_security_group.consul_sg.id}"
-  security_group_id        = "${data.aws_security_group.consul_sg.id}"
-}
 
-# [server>server] Serf LAN and WAN, UDP
-resource "aws_security_group_rule" "sgr_srv_2_srv_serf_wan_lan_udp" {
-  type                     = "ingress"
-  description              = "ig udp (serf: wan/lan)"
-  from_port                = 8301
-  to_port                  = 8302
-  protocol                 = "udp"
-  source_security_group_id = "${data.aws_security_group.consul_sg.id}"
-  security_group_id        = "${data.aws_security_group.consul_sg.id}"
-}
+# The needed security group rules needed to allow a communication between the consul nodes is already implemented in the
+# hashicorp repo for the consule module (https://github.com/hashicorp/terraform-aws-consul/blob/v0.4.4/modules/consul-client-security-group-rules/main.tf#L51).
 
-# [server>server] Server RPC, TCP
-resource "aws_security_group_rule" "sgr_srv_2_srv_rpc_tcp" {
-  type                     = "ingress"
-  description              = "ig tcp server RPC"
-  from_port                = 8300
-  to_port                  = 8300
-  protocol                 = "tcp"
-  source_security_group_id = "${data.aws_security_group.consul_sg.id}"
-  security_group_id        = "${data.aws_security_group.consul_sg.id}"
-}


### PR DESCRIPTION
With this MR we upgrade from v0.3.5 to v0.4.4 of the terraform-aws-consul module.
In order to stay compatible some sgrules had to be removed. Because these are now already defined in the terraform-aws-consul module.

Additionally the usage of CIDR blocks for defining the source for sg rules could be removed. Instead only rules, where a SG is the source are used.