### PR TITLE
B/51 docker pull issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ The data-centers of the COS are organized/ live in three different subnets.
 2. **Services**: This subnet contains the services that need no egress access to the internet. Ingress access is only granted for some of them over an ALB, but not directly.
 3. **Content-Connector**: This subnet contains services that need egress access to the internet in order to obtain data from conent-providers.
 
+### Docker Registry
+
+This Cluster Orchestration System allows to pull docker images from public docker registries like Docker Hub and from AWS ECR.
+
+Regarding AWS ECR, **it is only possible to pull from the registry of the AWS account and region where this COS is deployed to**. Thus you have to create an ECR in the same region on the same account and push your docker images there.
+
 ### HA-Setup
 
 ![deps](_docs/Cluster_Orchestration_System_HA.png)

--- a/examples/jobs/ping_service.nomad
+++ b/examples/jobs/ping_service.nomad
@@ -4,14 +4,10 @@ job "ping_service" {
   datacenters = ["public-services","private-services","content-connector","backoffice"]
   type = "service"
 
-  meta {
-    my-key = "example"
-  }
-
   # The group stanza defines a series of tasks that should be co-located on the same Nomad client.
   # Any task within a group will be placed on the same client.
   group "ping_service_group" {
-    count = 5
+    count = 4
 
     # restart-policy
     restart {
@@ -32,10 +28,7 @@ job "ping_service" {
       driver = "docker"
       config {
         # Docker Hub:
-        #image = "thobe/ping_service:0.0.9"
-        # AWS ECR playground: image = "<aws_account_id>.dkr.ecr.us-east-1.amazonaws.com/service/ping-service:0.0.7"
-        #args    = ["Hello, World!"]
-        image = "307557990628.dkr.ecr.us-east-1.amazonaws.com/service/ping-service:2018-04-15_11-16-11_0eaa8b1_dirty"
+        image = "thobe/ping_service:0.0.9"
       }
 
       logs {

--- a/examples/nomad-datacenter/README.md
+++ b/examples/nomad-datacenter/README.md
@@ -7,12 +7,12 @@ Per default the module will be deployed in us-east-1 (virginia) into three AZ's.
 
 ```bash
 # terraform init &&\
-# terraform plan -out dc.plan -var deploy_profile=<your-profile> &&\
+# terraform plan -out dc.plan -var deploy_profile=<your-profile> -var ami_id=<id of the ami to use for consul/ nomad nodes> &&\
 # terraform apply "dc.plan"
 
 # on playground
 terraform init &&\
-terraform plan -out dc.plan -var deploy_profile=playground &&\
+terraform plan -out dc.plan -var deploy_profile=playground -var ami_id=ami-1234567890 &&\
 terraform apply "dc.plan"
 ```
 

--- a/examples/nomad-datacenter/main.tf
+++ b/examples/nomad-datacenter/main.tf
@@ -35,7 +35,7 @@ module "nomad-datacenter" {
   ## required parameters
   vpc_id                   = "${data.aws_vpc.default.id}"
   subnet_ids               = "${data.aws_subnet_ids.all.ids}"
-  ami_id                   = "ami-a23feadf"
+  ami_id                   = "${var.ami_id}"
   consul_cluster_tag_key   = "consul-servers"
   consul_cluster_tag_value = "${local.stack_name}-${local.env_name}-consul-srv"
   server_sg_id             = "${aws_security_group.sg_nomad_server.id}"

--- a/examples/nomad-datacenter/vars.tf
+++ b/examples/nomad-datacenter/vars.tf
@@ -1,3 +1,8 @@
 variable "deploy_profile" {
   description = "Specify the local AWS profile configuration to use."
 }
+
+variable "ami_id" {
+  description = "Id of the AMI for the nomad and consul nodes."
+  default     = "ami-a23feadf"
+}

--- a/examples/nomad/README.md
+++ b/examples/nomad/README.md
@@ -7,12 +7,12 @@ Per default the module will be deployed in us-east-1 (virginia) into three AZ's.
 
 ```bash
 # terraform init &&\
-# terraform plan -out nm.plan -var deploy_profile=<your-profile> &&\
+# terraform plan -out nm.plan -var deploy_profile=<your-profile> -var ami_id=<id of the ami to use for consul/ nomad nodes> &&\
 # terraform apply "nm.plan"
 
 # on playground
 terraform init &&\
-terraform plan -out nm.plan -var deploy_profile=playground &&\
+terraform plan -out nm.plan -var deploy_profile=playground -var ami_id=ami-1234567890 &&\
 terraform apply "nm.plan"
 ```
 
@@ -28,7 +28,7 @@ export AWS_PROFILE=playground
 ### Run the test script
 
 ```bash
-./run_test.sh
+./run_tests.sh
 ```
 
 The result should look like this:

--- a/examples/nomad/main.tf
+++ b/examples/nomad/main.tf
@@ -2,8 +2,8 @@ locals {
   aws_region               = "us-east-1"
   stack_name               = "COS"
   env_name                 = "playground"
-  consul_ami_id            = "ami-a23feadf"
-  nomad_ami_id             = "ami-a23feadf"
+  consul_ami_id            = "${var.ami_id}"
+  nomad_ami_id             = "${var.ami_id}"
   consul_cluster_tag_key   = "consul-servers"
   consul_cluster_tag_value = "${local.stack_name}-SDCFG-consul-${random_pet.unicorn.id}"
 }

--- a/examples/nomad/vars.tf
+++ b/examples/nomad/vars.tf
@@ -1,3 +1,8 @@
 variable "deploy_profile" {
   description = "Specify the local AWS profile configuration to use."
 }
+
+variable "ami_id" {
+  description = "Id of the AMI for the nomad and consul nodes."
+  default     = "ami-a23feadf"
+}

--- a/modules/ami2/docker_config.json
+++ b/modules/ami2/docker_config.json
@@ -1,6 +1,3 @@
 {
-  "credsStore": "ecr-login",
-  "credHelpers": {
-    "https://index.docker.io/v1/": "pass"
-  }
+  "info": "This file will be written using the user-data of the nomad instances. See modules/nomad/user-data-nomad-server.sh and modules/nomad-datacenter/user-data-nomad-client.sh"
 }

--- a/modules/ami2/docker_config.json
+++ b/modules/ami2/docker_config.json
@@ -1,3 +1,6 @@
 {
-    "credsStore": "ecr-login"
+  "credsStore": "ecr-login",
+  "credHelpers": {
+    "https://index.docker.io/v1/": "pass"
+  }
 }

--- a/modules/ami2/run-nomad/run-nomad
+++ b/modules/ami2/run-nomad/run-nomad
@@ -161,8 +161,7 @@ client {
   enabled = true
 
   options   = {
-    "docker.auth.config"        = "/etc/docker/config.json"
-    "docker.auth.helper"        = "ecr-login"
+    "docker.auth.config"        = "/etc/docker/config.json"    
     "docker.privileged.enabled" = "true"
   }
 }

--- a/modules/nomad-datacenter/datacenter.tf
+++ b/modules/nomad-datacenter/datacenter.tf
@@ -62,6 +62,8 @@ module "consul_iam_policies_datacenter" {
   iam_role_id = "${module.data_center.iam_role_id}"
 }
 
+data "aws_caller_identity" "aws_account_id" {}
+
 # This script will configure and start Consul and Nomad
 data "template_file" "user_data_data_center" {
   template = "${file("${path.module}/user-data-nomad-client.sh")}"
@@ -74,5 +76,6 @@ data "template_file" "user_data_data_center" {
     map_bucket_name            = "${var.map_bucket_name}"
     device_to_mount_target_map = "${join(" ", var.device_to_mount_target_map)}"
     fs_type                    = "${var.fs_type}"
+    aws_account_id             = "${data.aws_caller_identity.aws_account_id.account_id}"
   }
 }

--- a/modules/nomad-datacenter/datacenter.tf
+++ b/modules/nomad-datacenter/datacenter.tf
@@ -77,5 +77,6 @@ data "template_file" "user_data_data_center" {
     device_to_mount_target_map = "${join(" ", var.device_to_mount_target_map)}"
     fs_type                    = "${var.fs_type}"
     aws_account_id             = "${data.aws_caller_identity.aws_account_id.account_id}"
+    aws_region                 = "${var.aws_region}"
   }
 }

--- a/modules/nomad-datacenter/user-data-nomad-client.sh
+++ b/modules/nomad-datacenter/user-data-nomad-client.sh
@@ -29,6 +29,9 @@ function configure_ecr_docker_credential_helper (){
   # These variables are passed in via Terraform template interplation
   log_info "Creating /etc/docker/config.json containing the credential helper for docker login to ECR"
   echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.us-east-1.amazonaws.com\": \"ecr-login\"\n\t}\n}' > /etc/docker/config.json" | sudo sh  
+
+  log_info "Creating \$HOME/.docker/config.json containing the credential helper for docker login to ECR"
+  echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.us-east-1.amazonaws.com\": \"ecr-login\"\n\t}\n}' > \$HOME/.docker/config.json" | sudo sh  
 }
 
 

--- a/modules/nomad-datacenter/user-data-nomad-client.sh
+++ b/modules/nomad-datacenter/user-data-nomad-client.sh
@@ -28,7 +28,7 @@ function log_info {
 function configure_ecr_docker_credential_helper (){ 
   # These variables are passed in via Terraform template interplation
   log_info "Creating /etc/docker/config.json containing the credential helper for docker login to ECR"
-  echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.\"${aws_region}\".amazonaws.com\": \"ecr-login\"\n\t}\n}' > /etc/docker/config.json" | sudo sh  
+  echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.${aws_region}.amazonaws.com\": \"ecr-login\"\n\t}\n}' > /etc/docker/config.json" | sudo sh
 
   log_info "Copy /etc/docker/config.json to /home/ec2-user/.docker/config.json"
   cp /etc/docker/config.json /home/ec2-user/.docker/

--- a/modules/nomad-datacenter/user-data-nomad-client.sh
+++ b/modules/nomad-datacenter/user-data-nomad-client.sh
@@ -25,6 +25,13 @@ function log_info {
   log "INFO" "$message"
 }
 
+function configure_ecr_docker_credential_helper (){ 
+  # These variables are passed in via Terraform template interplation
+  log_info "Creating /etc/docker/config.json containing the credential helper for docker login to ECR"
+  echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.us-east-1.amazonaws.com\": \"ecr-login\"\n\t}\n}' > /etc/docker/config.json" | sudo sh  
+}
+
+
 function setup_consul_and_nomad (){ 
   # These variables are passed in via Terraform template interplation
   log_info "Configuring consul."
@@ -125,7 +132,7 @@ function prepare_and_mount_device () {
   done
 }
 
-
+configure_ecr_docker_credential_helper
 setup_consul_and_nomad
 configure_efs
 

--- a/modules/nomad-datacenter/user-data-nomad-client.sh
+++ b/modules/nomad-datacenter/user-data-nomad-client.sh
@@ -28,10 +28,12 @@ function log_info {
 function configure_ecr_docker_credential_helper (){ 
   # These variables are passed in via Terraform template interplation
   log_info "Creating /etc/docker/config.json containing the credential helper for docker login to ECR"
-  echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.us-east-1.amazonaws.com\": \"ecr-login\"\n\t}\n}' > /etc/docker/config.json" | sudo sh  
+  echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.\"${aws_region}\".amazonaws.com\": \"ecr-login\"\n\t}\n}' > /etc/docker/config.json" | sudo sh  
 
-  log_info "Creating \$HOME/.docker/config.json containing the credential helper for docker login to ECR"
-  echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.us-east-1.amazonaws.com\": \"ecr-login\"\n\t}\n}' > \$HOME/.docker/config.json" | sudo sh  
+  log_info "Copy /etc/docker/config.json to /home/ec2-user/.docker/config.json"
+  cp /etc/docker/config.json /home/ec2-user/.docker/
+  chown ec2-user /home/ec2-user/.docker/config.json
+  chgrp ec2-user /home/ec2-user/.docker/config.json
 }
 
 

--- a/modules/nomad/servers.tf
+++ b/modules/nomad/servers.tf
@@ -60,6 +60,8 @@ module "consul_iam_policies_servers" {
   iam_role_id = "${module.nomad_servers.iam_role_id}"
 }
 
+data "aws_caller_identity" "aws_account_id" {}
+
 # This script will configure and start Consul and Nomad
 data "template_file" "user_data_server" {
   template = "${file("${path.module}/user-data-nomad-server.sh")}"
@@ -69,5 +71,6 @@ data "template_file" "user_data_server" {
     cluster_tag_key   = "${var.consul_cluster_tag_key}"
     cluster_tag_value = "${var.consul_cluster_tag_value}"
     datacenter        = "${var.datacenter_name}"
+    aws_account_id    = "${data.aws_caller_identity.aws_account_id.account_id}"
   }
 }

--- a/modules/nomad/servers.tf
+++ b/modules/nomad/servers.tf
@@ -72,5 +72,6 @@ data "template_file" "user_data_server" {
     cluster_tag_value = "${var.consul_cluster_tag_value}"
     datacenter        = "${var.datacenter_name}"
     aws_account_id    = "${data.aws_caller_identity.aws_account_id.account_id}"
+    aws_region        = "${var.aws_region}"
   }
 }

--- a/modules/nomad/user-data-nomad-server.sh
+++ b/modules/nomad/user-data-nomad-server.sh
@@ -10,5 +10,38 @@ set -e
 # From: https://alestic.com/2010/12/ec2-user-data-output/
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
-/opt/consul/bin/run-consul --client --cluster-tag-key "${cluster_tag_key}" --cluster-tag-value "${cluster_tag_value}"
-/opt/nomad/bin/run-nomad --server --num-servers "${num_servers}" --datacenter "${datacenter}"
+readonly SCRIPT_DIR="$(cd "$(dirname "$${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_NAME="$(basename "$0")"
+
+function log {
+  local readonly level="$1"
+  local readonly message="$2"
+  local readonly timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+  >&2 echo -e "$${timestamp} [$${level}] [$SCRIPT_NAME] $${message}"
+}
+
+function log_info {
+  local readonly message="$1"
+  log "INFO" "$message"
+}
+
+function configure_ecr_docker_credential_helper (){ 
+  # These variables are passed in via Terraform template interplation
+  log_info "Creating /etc/docker/config.json containing the credential helper for docker login to ECR"
+  echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.us-east-1.amazonaws.com\": \"ecr-login\"\n\t}\n}' > /etc/docker/config.json" | sudo sh    
+
+  log_info "Creating \$HOME/.docker/config.json containing the credential helper for docker login to ECR"
+  echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.us-east-1.amazonaws.com\": \"ecr-login\"\n\t}\n}' > \$HOME/.docker/config.json" | sudo sh  
+}
+
+function setup_consul_and_nomad (){ 
+
+  # These variables are passed in via Terraform template interplation
+  log_info "Configuring consul."
+  /opt/consul/bin/run-consul --client --cluster-tag-key "${cluster_tag_key}" --cluster-tag-value "${cluster_tag_value}"
+  log_info "Configuring nomad."
+  /opt/nomad/bin/run-nomad --server --num-servers "${num_servers}" --datacenter "${datacenter}"
+}
+
+configure_ecr_docker_credential_helper
+setup_consul_and_nomad

--- a/modules/nomad/user-data-nomad-server.sh
+++ b/modules/nomad/user-data-nomad-server.sh
@@ -28,10 +28,12 @@ function log_info {
 function configure_ecr_docker_credential_helper (){ 
   # These variables are passed in via Terraform template interplation
   log_info "Creating /etc/docker/config.json containing the credential helper for docker login to ECR"
-  echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.us-east-1.amazonaws.com\": \"ecr-login\"\n\t}\n}' > /etc/docker/config.json" | sudo sh    
+  echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.\"${aws_region}\".amazonaws.com\": \"ecr-login\"\n\t}\n}' > /etc/docker/config.json" | sudo sh  
 
-  log_info "Creating \$HOME/.docker/config.json containing the credential helper for docker login to ECR"
-  echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.us-east-1.amazonaws.com\": \"ecr-login\"\n\t}\n}' > \$HOME/.docker/config.json" | sudo sh  
+  log_info "Copy /etc/docker/config.json to /home/ec2-user/.docker/config.json"
+  cp /etc/docker/config.json /home/ec2-user/.docker/
+  chown ec2-user /home/ec2-user/.docker/config.json
+  chgrp ec2-user /home/ec2-user/.docker/config.json
 }
 
 function setup_consul_and_nomad (){ 

--- a/modules/nomad/user-data-nomad-server.sh
+++ b/modules/nomad/user-data-nomad-server.sh
@@ -28,7 +28,7 @@ function log_info {
 function configure_ecr_docker_credential_helper (){ 
   # These variables are passed in via Terraform template interplation
   log_info "Creating /etc/docker/config.json containing the credential helper for docker login to ECR"
-  echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.\"${aws_region}\".amazonaws.com\": \"ecr-login\"\n\t}\n}' > /etc/docker/config.json" | sudo sh  
+  echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.${aws_region}.amazonaws.com\": \"ecr-login\"\n\t}\n}' > /etc/docker/config.json" | sudo sh
 
   log_info "Copy /etc/docker/config.json to /home/ec2-user/.docker/config.json"
   cp /etc/docker/config.json /home/ec2-user/.docker/


### PR DESCRIPTION
# Changes
With this adjustment it is possible to load docker images from public docker repositories (like Docker Hub) and from the ECR of the AWS account wherein the COS is deployed.

Therefore instead of using the docker credStore option, to enable the ecr-login helper, only the credHelper option is used only for this purpose. Thus it is possible to specify to use the ecr-login helper only for the ECR of the AWS account. All other docker pull requests (i.e. to Docker Hub) are made without credentials.

**This solves #51.**

# Tested
1. Tested by deploying the ping-service using the image from docker hub `image = "thobe/ping_service:0.0.9"`
2. Tested by deploying the ping-service using the image from the ECR of the account where the COS was deployed to (root-example): `image = "<aws_account_id>.dkr.ecr.us-east-1.amazonaws.com"`
