### PR TITLE
NEW: Devmode: advanced enhanced - Consul + Fabio + ( Elasticsearch + Kibana )

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,5 @@ bst.plan
 # folder with generated files
 out/
 /examples/jobs/grafana/dashboard_navcloud_poi_parking.json
-/examples/jobs/prometheus/version
 
-examples/jobs/grafana/haproxy/version
-
-examples/jobs/envoy/version
+**/version

--- a/examples/devmode/README.md
+++ b/examples/devmode/README.md
@@ -111,11 +111,11 @@ has to be configured. This time in the `fabio_docker.nomad` job description.
 
 1. Configuration have to be done at: `/etc/docker/daemon.json`:
 
-  ```json
-  {
-      "insecure-registries" : [ "localhost:5000" ]
-  }
-  ```
+   ```json
+   {
+     "insecure-registries" : [ "localhost:5000" ]
+   }
+   ```
 1. Restart the daemon.
 
 #### MacOS

--- a/examples/devmode/README.md
+++ b/examples/devmode/README.md
@@ -1,24 +1,32 @@
 # COS Development Mode
 
 ## Development Mode - Simple
-Local setup for development purposes. This will provide a local Docker registry and a local nomad running.
+
+Local setup for development purposes.
+This will provide a local Docker registry and a local nomad running.
 
 ### Limitation: Localhost Only Access
-In this configuration it will only be possible to use localhost and hence is inconvenient if one has to use the host ip address to interconnect services
+
+In this configuration it will only be possible to use localhost and
+hence is inconvenient if one has to use the host ip address to interconnect services.
 
 -> Section: **Development Mode - Advanced**
 
 ### Quickstart
+
 ```
 sudo nomad agent -dev -dc="testing"
 # Note: Use a new terminal to preserve log output of the nomad agent.
 export NOMAD_ADDR=http://localhost:4646
 nomad run registry/creg.nomad
 ```
-### Setup
-Start nomad in dev mode and configure the datacenter to reflect the actual one once deployed.
-* `sudo nomad agent -dev -dc="testing"` ( default dc: "dc1" )
 
+### Setup
+
+Start nomad in dev mode and configure the datacenter
+to reflect the actual one once deployed.
+
+* `sudo nomad agent -dev -dc="testing"` ( default dc: "dc1" )
 
 ## Development Mode - Advanced
 For the setup of the advanced mode a specific nomad configuration file is provided: `dev.hcl`. This configuration provides a local server and client setup. And avoids and uses the host ip address to setup the client node.
@@ -36,36 +44,48 @@ nomad run registry/creg.nomad
 ```
 
 ## Local Docker Registry
-1. One time: Configure the Docker daemon to accept local Docker registry. Check the subsections for OS support.
-2. Deploy a local Docker registry in the local nomad
-   * `nomad run creg.nomad`
-   
-NOTE:
+
+1. One time: Configure the Docker daemon to accept local Docker registry.
+   Check the subsections for OS support.
+1. Deploy a local Docker registry in the local nomad
+  * `nomad run creg.nomad`
+
+### NOTE
+
 * Advanced mode: Replace `localhost` with your `<host_ip_address>`.
 
 ### Setup
+
 #### Linux
+
 1. Configuration have to be done at: `/etc/docker/daemon.json`:
+
 ```
 {
     "insecure-registries" : [ "localhost:5000" ]
 }
 
 ```
-2. Restart the daemon.
+
+1. Restart the daemon.
 
 #### MacOS
-Using the "Docker Desktop" just check out the "Preferences/Daemon" section and add the local Docker registry `localhost:5000` at "Insecure registries".
 
+Using the "Docker Desktop" just check out the "Preferences/Daemon" section and
+add the local Docker registry `localhost:5000` at "Insecure registries".
 
 ### Usage
+
 #### Pushing to Docker Registry
+
 ```
 docker build -t samplejob .
 docker tag samplejob:latest localhost:5000/samplejob:latest
 docker push localhost:5000/samplejob:latest
 ```
+
 ##### Using with nomad
+
 ```
 job "samplejob" {
   datacenters = [ "testing" ]

--- a/examples/devmode/README.md
+++ b/examples/devmode/README.md
@@ -86,13 +86,17 @@ has to be updated to match your current setup.
 
 #### Fabio
 
-Fabio just works out of the box. No additional adjustments are needed
+Fabio just works out of the box
+despite the fact that the _datacenter_ variable
+should be adjusted according the local setup.
+No further additional adjustment is needed
 if fabio is used natively with the nomad `exec` driver.
 
 ##### Docker
 
 For Fabio running in a Docker container again the `<host_ip_address>`
-has to be configured. This time in the `fabio_docker.nomad` job description.
+has to be configured as well as the _datacenter_.
+This time in the `fabio_docker.nomad` job description.
 
 ## Local Docker Registry
 

--- a/examples/devmode/README.md
+++ b/examples/devmode/README.md
@@ -78,6 +78,11 @@ has to be updated to match your current setup.
 Fabio just works out of the box. No additional adjustments are needed
 if fabio is used natively with the nomad `exec` driver.
 
+##### Docker
+
+For Fabio running in a Docker container again the `<host_ip_address>`
+has to be configured. This time in the `fabio_docker.nomad` job description.
+
 ## Local Docker Registry
 
 1. One time: Configure the Docker daemon to accept local Docker registry.

--- a/examples/devmode/README.md
+++ b/examples/devmode/README.md
@@ -29,19 +29,54 @@ to reflect the actual one once deployed.
 * `sudo nomad agent -dev -dc="testing"` ( default dc: "dc1" )
 
 ## Development Mode - Advanced
-For the setup of the advanced mode a specific nomad configuration file is provided: `dev.hcl`. This configuration provides a local server and client setup. And avoids and uses the host ip address to setup the client node.
 
-To use the advanced mode just follow the instructions for the simple mode and replace `localhost` with `<host_ip_address>`.
+For the setup of the advanced mode a specific nomad configuration file
+is provided: `nomad.hcl`. This configuration provides a local server and
+client setup. And avoids and uses the host ip address to setup the client node.
+Furthermore a local setup for consul is provided with the `consul.hcl`.
+This will allow the interaction with the service discovery and
+the load balancer ( fabio ).
 
-NOTE: Remember not to check in your host specific configuration files!
+To use the advanced mode just follow the instructions for the simple mode and
+replace `localhost` with `<host_ip_address>`.
+The `<host_ip_address>` has to be configured in the `nomad.hcl` and
+in the `consul.hcl` by replacing the `<host_ip_address>` place holder.
+
+TODO: provide a script to do this ( using sed ).
+
+### NOTE
+
+Remember: Do NOT check in your host specific configuration files!
 
 ### Quickstart
+
 ```
-sudo nomad agent -config=dev.hcl
+consul agent -config-file=consul.hcl
+sudo nomad agent -config=nomad.hcl
 # Note: Use a new terminal to preserve log output of the nomad agent.
 export NOMAD_ADDR=http://<host_ip_address>:4646
 nomad run registry/creg.nomad
 ```
+
+### Service Discovery
+
+#### Quickstart
+
+```
+consul agent -dev -node local -> not working with fabio!
+```
+
+#### Local Consul
+
+The nomad agent configuration has to be adapted in order to support
+automatic service registration in Consul.
+To make this work the `<host_ip_address>` in the `nomad.hcl`
+has to be updated to match your current setup.
+
+#### Fabio
+
+Fabio just works out of the box. No additional adjustments are needed
+if fabio is used natively with the nomad `exec` driver.
 
 ## Local Docker Registry
 

--- a/examples/devmode/README.md
+++ b/examples/devmode/README.md
@@ -14,7 +14,7 @@ hence is inconvenient if one has to use the host ip address to interconnect serv
 
 ### Quickstart
 
-```
+```bash
 sudo nomad agent -dev -dc="testing"
 # Note: Use a new terminal to preserve log output of the nomad agent.
 export NOMAD_ADDR=http://localhost:4646
@@ -42,15 +42,13 @@ replace `localhost` with `<host_ip_address>`.
 The `<host_ip_address>` has to be configured in the `nomad.hcl` and
 in the `consul.hcl` by replacing the `<host_ip_address>` place holder.
 
-TODO: provide a script to do this ( using sed ).
-
 ### NOTE
 
 Remember: Do NOT check in your host specific configuration files!
 
 ### Quickstart
 
-```
+```bash
 consul agent -config-file=consul.hcl
 sudo nomad agent -config=nomad.hcl
 # Note: Use a new terminal to preserve log output of the nomad agent.
@@ -75,7 +73,7 @@ Or call the `devmode.sh` script:
 
 #### Quickstart
 
-```
+```bash
 consul agent -dev -node local -> not working with fabio!
 ```
 
@@ -101,7 +99,7 @@ has to be configured. This time in the `fabio_docker.nomad` job description.
 1. One time: Configure the Docker daemon to accept local Docker registry.
    Check the subsections for OS support.
 1. Deploy a local Docker registry in the local nomad
-  * `nomad run creg.nomad`
+  * `nomad run registry/creg.nomad`
 
 ### NOTE
 
@@ -113,13 +111,11 @@ has to be configured. This time in the `fabio_docker.nomad` job description.
 
 1. Configuration have to be done at: `/etc/docker/daemon.json`:
 
-```
-{
-    "insecure-registries" : [ "localhost:5000" ]
-}
-
-```
-
+  ```json
+  {
+      "insecure-registries" : [ "localhost:5000" ]
+  }
+  ```
 1. Restart the daemon.
 
 #### MacOS
@@ -131,7 +127,7 @@ add the local Docker registry `localhost:5000` at "Insecure registries".
 
 #### Pushing to Docker Registry
 
-```
+```bash
 docker build -t samplejob .
 docker tag samplejob:latest localhost:5000/samplejob:latest
 docker push localhost:5000/samplejob:latest
@@ -139,7 +135,7 @@ docker push localhost:5000/samplejob:latest
 
 ##### Using with nomad
 
-```
+```hcl
 job "samplejob" {
   datacenters = [ "testing" ]
   ...

--- a/examples/devmode/consul.hcl
+++ b/examples/devmode/consul.hcl
@@ -1,0 +1,15 @@
+{
+  "bind_addr": "0.0.0.0",
+  "client_addr": "<host_ip_address>",
+  "datacenter": "testing",
+  "data_dir": "/tmp/consul",
+  "log_level": "DEBUG",
+  "enable_debug": true,
+  "node_name": "consul-devagent",
+  "server": true,
+  "bootstrap_expect": 1,
+  "ui": true,
+  "leave_on_terminate": false,
+  "skip_leave_on_interrupt": true,
+  "rejoin_after_leave": true
+}

--- a/examples/devmode/nomad.hcl
+++ b/examples/devmode/nomad.hcl
@@ -20,3 +20,7 @@ server {
   bootstrap_expect = 1
   num_schedulers   = 1
 }
+
+consul {
+  address = "<host_ip_address>:8500"
+}

--- a/examples/jobs/fabio.nomad
+++ b/examples/jobs/fabio.nomad
@@ -8,7 +8,7 @@ job "fabio" {
   }
   group "fabio" {
     task "fabio" {
-      driver = "exec"
+      driver = "exec" # Linux only!
       config {
         command = "fabio-1.5.10-go1.11.1-linux_amd64"
       }

--- a/examples/jobs/fabio.nomad
+++ b/examples/jobs/fabio.nomad
@@ -1,4 +1,3 @@
-
 job "fabio" {
   datacenters = ["public-services"]
 
@@ -11,11 +10,11 @@ job "fabio" {
     task "fabio" {
       driver = "exec"
       config {
-        command = "fabio-1.5.8-go1.10-linux_amd64"
+        command = "fabio-1.5.10-go1.11.1-linux_amd64"
       }
 
       artifact {
-        source = "https://github.com/eBay/fabio/releases/download/v1.5.8/fabio-1.5.8-go1.10-linux_amd64"
+        source = "https://github.com/fabiolb/fabio/releases/download/v1.5.10/fabio-1.5.10-go1.11.1-linux_amd64"
       }
 
       resources {

--- a/examples/jobs/fabio_docker.nomad
+++ b/examples/jobs/fabio_docker.nomad
@@ -1,0 +1,51 @@
+job "fabio" {
+  datacenters = ["testing"]
+
+  type = "system"
+
+  update {
+    stagger = "5s"
+    max_parallel = 1
+  }
+
+  group "fabio" {
+    task "fabio" {
+      driver = "docker"
+      config {
+        image = "fabiolb/fabio:latest"
+
+        port_map = {
+          http = 9999
+          ui   = 9998
+        }
+
+        volumes = [
+          "local/fabio.properties:/etc/fabio/fabio.properties"
+        ]
+      }
+
+      resources {
+        cpu = 500
+        memory = 128
+        network {
+          mbits = 1
+
+          port "http" {
+            static = 9999
+          }
+          port "ui" {
+            static = 9998
+          }
+        }
+      }
+
+      template {
+        data = <<EOH
+registry.consul.addr = <host_ip_address>:8500
+EOH
+        destination = "local/fabio.properties"
+        change_mode = "noop"
+      }
+    }
+  }
+}

--- a/examples/jobs/logging.nomad
+++ b/examples/jobs/logging.nomad
@@ -1,3 +1,4 @@
+# FIXME: Not sure if this setup is working. Currently the COS does not provide support for Consul DNS. DNS should be avoided as much as possible. Hence it is not going to be added as a "feature".
 job "logging" {
   datacenters = ["backoffice"]
   type = "service"
@@ -120,7 +121,6 @@ EOH
       template {
         data = <<EOH
 server.name: logging-cluster-ui
-server.host: "0"
 
 elasticsearch.url: "http://elasticsearch.service.consul:{{ env "NOMAD_PORT_elasticsearch_http" }}/"
 

--- a/examples/jobs/logging/elasticsearch/Dockerfile
+++ b/examples/jobs/logging/elasticsearch/Dockerfile
@@ -1,5 +1,6 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.4
 
+COPY elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
 
 #################################################
 # NOTE: The following lines can keep untouched. #

--- a/examples/jobs/logging/elasticsearch/Dockerfile
+++ b/examples/jobs/logging/elasticsearch/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3
+FROM docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.4
+
 
 #################################################
 # NOTE: The following lines can keep untouched. #

--- a/examples/jobs/logging/elasticsearch/Makefile
+++ b/examples/jobs/logging/elasticsearch/Makefile
@@ -1,5 +1,5 @@
 category    	:= support/logging
-name        	:= lds
+name        	:= lbe
 
 docker_dir := .
 

--- a/examples/jobs/logging/elasticsearch/Makefile
+++ b/examples/jobs/logging/elasticsearch/Makefile
@@ -1,47 +1,75 @@
-category := service
-name     := elasticsearch
-aws_reg  	:= eu-central-1
-aws_profile := playground
+category    	:= support/logging
+name        	:= lds
 
-#################################################################################################################
+docker_dir := .
+
+# FIXME: DO NOT COMMIT THIS if true!!!
+registry_local     := false
+registry_local_url := "<host_ip_address>:5000"
+latest_tag         := false
+
+# Registry: AWS - default configuration, if unset environment variables
+AWS_REGION    ?= eu-central-1
+AWS_PROFILE		?= integration
+
+################################################################################################################
 # NOTE: The following lines can keep untouched. There is nothing more to configure the category and the name.  #
 #################################################################################################################
 
-# obtain aws account id
-aws_aid     := $(shell aws sts get-caller-identity --output text --query 'Account' --profile $(aws_profile))
+# Registry: LOCAL
+ifeq ($(registry_local), true)
+	registry_url := $(registry_local_url)
+	creds := $(echo "Using local docker registry: " $(registry_url))
+# Registry: AWS
+else
+	# obtain aws account id
+	aws_aid  := $(shell aws sts get-caller-identity --output text --query 'Account' --profile $(AWS_PROFILE))
+	registry_url  := $(aws_aid).dkr.ecr.$(AWS_REGION).amazonaws.com
 
-ecr_url  := $(aws_aid).dkr.ecr.$(aws_reg).amazonaws.com
+	# Create credentials for Docker for AWS ecr login
+	creds := $(shell aws ecr get-login --no-include-email --region $(AWS_REGION) --profile $(AWS_PROFILE))
+endif
 
 # Create version tag from git commit message. Indicate if there are uncommited local changes.
-date := $(shell date '+%Y-%m-%d_%H-%M-%S')
-rev  := $(shell git rev-parse --short HEAD)
-flag := $(shell git diff-index --quiet HEAD -- || echo "_dirty";)
-tag  := $(date)$(rev)$(flag)
+ifeq ($(latest_tag), true)
+	tag  := "latest"
+else
+	date := $(shell date '+%Y-%m-%d_%H-%M-%S')
+	rev  := $(shell git rev-parse --short HEAD)
+	flag := $(shell git diff-index --quiet HEAD -- || echo "_dirty";)
+	tag  := $(date)_$(rev)$(flag)
+endif
 
-# Create credentials for Docker for AWS ecr login
-creds := $(shell aws ecr get-login --no-include-email --region $(aws_reg) --profile $(aws_profile))
+all: clean build push finish
 
-all: clean version build push finish
+build: version delim
+	@echo "[INFO] Building and tagging image"
+	docker build -t $(category)/$(name) --build-arg VERSION=$(tag) .
+	@docker tag $(category)/$(name):latest $(registry_url)/$(category)/$(name):$(tag)
 
-version: delim
+push: credentials delim
+	@echo "[INFO] Pushing image to Registry"
+	@docker push $(registry_url)/$(category)/$(name):$(tag)
+
+clean:
+	@rm -f version
+
+
+version: delim chgwork
 	@echo "[INFO] Building version:"
 	@echo $(tag) | tee version
 
 credentials: delim
-	@echo "[INFO] Login to AWS ECR"
+	@echo "[INFO] Login to Registry"
 	@$(creds)
 
-build: delim
-	@echo "[INFO] Building and tagging image"
-	docker build -t $(category)/$(name) --build-arg VERSION=$(tag) .
-	@docker tag $(category)/$(name):latest $(ecr_url)/$(category)/$(name):$(tag)
+chgwork: delim
+	@echo "[INFO] Changing to work directory: $(docker_dir)"
+	@cd $(docker_dir)
 
-push: credentials delim
-	@echo "[INFO] Pushing image to AWS ECR"
-	@docker push $(ecr_url)/$(category)/$(name):$(tag)
-
-clean:
-	@rm -f version
+chgroot: delim
+	@echo "[INFO] Changing to root directory"
+	cd -
 
 delim:
 	@echo "------------------------------------------------------------------------------------------------"

--- a/examples/jobs/logging/elasticsearch/elasticsearch.yml
+++ b/examples/jobs/logging/elasticsearch/elasticsearch.yml
@@ -1,0 +1,9 @@
+cluster.name: ${CLUSTER_NAME}
+network.host: ${NETWORK_HOST}
+
+# minimum_master_nodes need to be explicitly set when bound on a public IP
+# set to 1 to allow single node clusters
+# Details: https://github.com/elastic/elasticsearch/pull/17288
+discovery.zen.minimum_master_nodes: ${DISCOVERY_ZEN_MINIMUM_MASTER_NODES}
+
+action.auto_create_index: ${ACTION_AUTO_CREATE_INDEX}

--- a/examples/jobs/logging/elasticsearch/lbe.nomad
+++ b/examples/jobs/logging/elasticsearch/lbe.nomad
@@ -1,8 +1,8 @@
-job "lds" {
+job "lbe" {
   datacenters = ["testing"]
   type = "service"
 
-  group "lds_group" {
+  group "lbe_group" {
     count = 1
 
     restart {
@@ -17,8 +17,8 @@ job "lds" {
       config {
         image = "docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.4"
         # Option2:
-        # For local Docker image builds - check NOTE section below.
-        # image = "<host_ip_address>:5000/support/logging/lds:latest"
+        # For local Docker image builbe - check NOTE section below.
+        # image = "<host_ip_address>:5000/support/logging/lbe:latest"
 
 
         port_map = {
@@ -44,11 +44,11 @@ job "lds" {
       }
 
       service {
-        name = "lds"
-        tags = ["urlprefix-/lds"] # fabio
+        name = "lbe"
+        tags = ["urlprefix-/lbe"] # fabio
         port = "http"
         check {
-          name     = "Logging Data Store Alive State"
+          name     = "Logging Backend Alive State"
           port     = "http"
           type     = "http"
           method   = "GET"
@@ -67,7 +67,7 @@ job "lds" {
         #        OOS killed the container because the memory limit was reached.
         #        Might be a bug in Java.
         ES_JAVA_OPTS = "-Xmx256m -Xms256m"
-        CLUSTER_NAME = "es-logging-cluster"
+        CLUSTER_NAME = "logging-backend"
         NETWORK_HOST = "0.0.0.0"
         DISCOVERY_ZEN_MINIMUM_MASTER_NODES = "1"
         ACTION_AUTO_CREATE_INDEX = "true"

--- a/examples/jobs/logging/elasticsearch/lds.nomad
+++ b/examples/jobs/logging/elasticsearch/lds.nomad
@@ -1,0 +1,93 @@
+job "lds" {
+  datacenters = ["testing"]
+  type = "service"
+
+  group "lds_group" {
+    count = 1
+
+    restart {
+      attempts = 10
+      interval = "5m"
+      delay    = "25s"
+      mode     = "delay"
+    }
+
+    task "elasticsearch" {
+      driver = "docker"
+      config {
+        image = "docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.4"
+        # Option2:
+        # For local Docker image builds - check NOTE section below.
+        # image = "<host_ip_address>:5000/support/logging/lds:latest"
+
+
+        port_map = {
+          http = 9200
+          node = 9300
+        }
+
+        ulimit {
+          nofile = "65536:65536"
+        }
+      }
+
+      resources {
+        cpu    =  300 # MHz
+        memory = 1024 # MB
+        network {
+          mbits = 10
+          port "http" {
+            static = "29200"
+          }
+          port "node" {}
+        }
+      }
+
+      service {
+        name = "lds"
+        tags = ["urlprefix-/lds"] # fabio
+        port = "http"
+        check {
+          name     = "Logging Data Store Alive State"
+          port     = "http"
+          type     = "http"
+          method   = "GET"
+          path     = "/_cluster/health"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
+      # NOTE: It might look a bit weird to use environment variables here and then to add them in the template section. This is done to show two possibilities to configure Elasticsearch:
+      # 1. Creating a custom Docker image which the "elasticsearch.yml" baked in and configure it using the "env" section
+      # 2. Using the template functionality of Nomad to inject a customized configuration
+      # Suggestion: For this specific setup it might be better to avoid the additional Docker volume mount and just provide an Elasticsearch configuration using environment variables. For local testing without the need of a local Docker registry the mounting could be still convenient.
+      env {
+        # FIXME: Using values near the memory limit did not work.
+        #        OOS killed the container because the memory limit was reached.
+        #        Might be a bug in Java.
+        ES_JAVA_OPTS = "-Xmx256m -Xms256m"
+        CLUSTER_NAME = "es-logging-cluster"
+        NETWORK_HOST = "0.0.0.0"
+        DISCOVERY_ZEN_MINIMUM_MASTER_NODES = "1"
+        ACTION_AUTO_CREATE_INDEX = "true"
+      }
+
+      template {
+        data = <<EOH
+cluster.name: ${CLUSTER_NAME}
+network.host: ${NETWORK_HOST}
+
+# minimum_master_nodes need to be explicitly set when bound on a public IP
+# set to 1 to allow single node clusters
+# Details: https://github.com/elastic/elasticsearch/pull/17288
+discovery.zen.minimum_master_nodes: ${DISCOVERY_ZEN_MINIMUM_MASTER_NODES}
+
+action.auto_create_index: ${ACTION_AUTO_CREATE_INDEX}
+EOH
+        destination = "local/elasticsearch.yml"
+        change_mode = "noop"
+      }
+    }
+  }
+}

--- a/examples/jobs/logging/kibana/lfe.nomad
+++ b/examples/jobs/logging/kibana/lfe.nomad
@@ -1,8 +1,8 @@
-job "lui" {
+job "lfe" {
   datacenters = ["testing"]
   type = "service"
 
-  group "lui_group" {
+  group "lfe_group" {
     count = 1
 
     restart {
@@ -36,15 +36,15 @@ job "lui" {
       }
 
       service {
-        name = "lui"
-        tags = ["urlprefix-/lui"] # Fabio
+        name = "lfe"
+        tags = ["urlprefix-/lfe"] # Fabio
         port = "http"
         check {
-          name     = "Logging UI Alive State"
+          name     = "Logging Frontend Alive State"
           port     = "http"
           type     = "http"
           method   = "GET"
-          path     = "/lui/api/status"
+          path     = "/lfe/api/status"
           interval = "10s"
           timeout  = "2s"
         }
@@ -52,8 +52,8 @@ job "lui" {
 
       # SEE: www.elastic.co/guide/en/kibana/current/settings.html
       env {
-        SERVER_NAME            = "logging-cluster-ui"
-        SERVER_BASEPATH        = "/lui"
+        SERVER_NAME            = "logging-frontend"
+        SERVER_BASEPATH        = "/lfe"
         SERVER_REWRITEBASEPATH = "true"
         # NOTE: TESTING:
         #       Only for local setups where everything is running on one machine

--- a/examples/jobs/logging/kibana/lui.nomad
+++ b/examples/jobs/logging/kibana/lui.nomad
@@ -1,0 +1,65 @@
+job "lui" {
+  datacenters = ["testing"]
+  type = "service"
+
+  group "lui_group" {
+    count = 1
+
+    restart {
+      attempts = 10
+      interval = "5m"
+      delay    = "25s"
+      mode     = "delay"
+    }
+
+    # NOTE: Add HAProxy configuration is NOT needed!
+    #       Kibana already does the trick with the options:
+    #       . SERVER_BASEPATH
+    #       . SERVER_REWRITEBASEPATH
+
+    task "kibana" {
+      driver = "docker"
+      config {
+        image = "docker.elastic.co/kibana/kibana-oss:6.5.4"
+        port_map = {
+          http = 5601
+        }
+      }
+
+      resources {
+        cpu    = 200 # MHz
+        memory = 300 # MB
+        network {
+          mbits = 10
+          port "http" {}
+        }
+      }
+
+      service {
+        name = "lui"
+        tags = ["urlprefix-/lui"] # Fabio
+        port = "http"
+        check {
+          name     = "Logging UI Alive State"
+          port     = "http"
+          type     = "http"
+          method   = "GET"
+          path     = "/lui/api/status"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
+      # SEE: www.elastic.co/guide/en/kibana/current/settings.html
+      env {
+        SERVER_NAME            = "logging-cluster-ui"
+        SERVER_BASEPATH        = "/lui"
+        SERVER_REWRITEBASEPATH = "true"
+        # NOTE: TESTING:
+        #       Only for local setups where everything is running on one machine
+        #       Furthermore that the port mentioned here matches the one configured in: lds.nomad.
+        ELASTICSEARCH_URL      = "http://${attr.unique.network.ip-address}:29200/"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR further enhances the development mode support with including a Consul configuration which can be run locally and then allows the usage of Fabio.

Furthermore this PR provides an Elasticsearch and Kibana setup to demonstrate the functionality.
Kibana can then be accessed using Fabio's path based routing: `<host>:9999/lui`.

An other nice outcome of this POC is the evaluation of different Elasticsearch configuration possibilities with nomad. Two ways are shown in `lds.nomad`:
1. Using *templates* and file mounting.
1. Using *environment* variables.