### PR TITLE
Startup Script for devmode incl. templating

### DIFF
--- a/examples/devmode/README.md
+++ b/examples/devmode/README.md
@@ -58,6 +58,19 @@ export NOMAD_ADDR=http://<host_ip_address>:4646
 nomad run registry/creg.nomad
 ```
 
+Or call the `devmode.sh` script:
+
+```bash
+# generic call
+# ./devmode.sh <host_ip_address> [<name of datacenter>]
+
+# start devmode with consul and nomad using datacenter named "testing"
+./devmode.sh 192.168.1.10
+
+# start devmode with consul and nomad using datacenter named "my-datacenter-name"
+./devmode.sh 192.168.1.10 my-datacenter-name
+```
+
 ### Service Discovery
 
 #### Quickstart

--- a/examples/devmode/consul.hcl
+++ b/examples/devmode/consul.hcl
@@ -1,7 +1,7 @@
 {
-  "bind_addr": "0.0.0.0",
-  "client_addr": "<host_ip_address>",
-  "datacenter": "testing",
+  "bind_addr": "{{host_ip_address}}",
+  "client_addr": "{{host_ip_address}}",
+  "datacenter": "{{datacenter}}",
   "data_dir": "/tmp/consul",
   "log_level": "DEBUG",
   "enable_debug": true,

--- a/examples/devmode/devmode.sh
+++ b/examples/devmode/devmode.sh
@@ -86,6 +86,7 @@ function start_nomad {
   local readonly workingDir=$1
   log_info "Starting nomad"
   nomadcmd="sudo nomad agent -config=${workingDir}/nomad.hcl &> ${workingDir}/nomad.log &"
+  sudo -v # needed to force sudo in shell
   eval "${nomadcmd}"
 }
 

--- a/examples/devmode/devmode.sh
+++ b/examples/devmode/devmode.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+set -o errexit
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_NAME="$(basename "$0")"
+
+function log {
+  local readonly level="$1"
+  local readonly message="$2"
+  local readonly timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+  >&2 echo -e "${timestamp} [${level}] [$SCRIPT_NAME] ${message}"
+}
+
+function log_info {
+  local readonly message="$1"
+  log "INFO" "$message"
+}
+
+
+function log_error {
+  local readonly message="$1"
+  log "ERROR" "$message"
+}
+
+function assert_is_installed {
+  local readonly name="$1"
+
+  if [[ ! $(command -v ${name}) ]]; then
+    log_error "The binary '$name' is required by this script but is not installed or in the system's PATH."
+    exit 1
+  fi
+}
+
+function checkIp {
+  local readonly ipAddr=$1
+
+  set +o errexit  
+  matchResult=$(echo "${ipAddr}" | grep "^[0-9]\{0,3\}\.[0-9]\{0,3\}\.[0-9]\{0,3\}\.[0-9]\{0,3\}$")
+  set -o errexit
+
+  if [ "$matchResult" != "$ipAddr" ]; then
+    log_error "Given ipAddr=${ipAddr} is not valid ${matchResult}"
+    exit 1
+  fi
+}
+
+function printUsage {
+  echo "Usage: ${SCRIPT_NAME} <hostIpAddr>"
+  echo -e "\thostIpAddr ... ip address of your host that should be used to communicate instead of localhost."
+}
+
+function copy_files {
+  tempDir=$(mktemp -d)
+  log_info "Copy the configuration files to ${tempDir}"
+
+  cp -R ../devmode ${tempDir}
+  echo "${tempDir}/devmode"
+}
+
+function replaceTemplateVarInFiles {
+  local readonly workingDir=$1
+  local readonly templateToReplace=$2
+  local readonly value=$3
+
+  files=(consul.hcl registry/creg.nomad nomad.hcl fabio_docker.nomad)
+
+  for item in ${files[*]}
+  do
+    file=${workingDir}/${item}
+    log_info "Replacing ${templateToReplace} by ${value} in ${file}."
+    command="sed -i.bak s/${templateToReplace}/${value}/g ${file}"
+    #log_info "\tCalling ${command}"
+    eval ${command}
+  done
+}
+
+function run {
+  assert_is_installed "nomad"
+  assert_is_installed "consul"
+
+  local readonly dataCenterDefault="testing"
+ 
+  local readonly ipAddr=$1
+  local readonly datacenter=$2
+
+
+  if [[ -z "$ipAddr" ]]; then
+    log_error "Parameter IpAddr is missing."
+    printUsage
+    exit 1
+  fi
+
+  if [[ -z "$datacenter" ]]; then
+    log_error "Parameter datacenter is missing using the default value '${dataCenterDefault}' instead."
+    datacenter=${dataCenterDefault}
+  fi
+
+  # check if the given parameter is a valid ip address
+  checkIp "${ipAddr}"
+
+  # copy the files into a temporary file in order to be able to replace template variables
+  workingDir=$(copy_files)
+
+  replaceTemplateVarInFiles "${workingDir}" "{{host_ip_address}}" "${ipAddr}"
+  replaceTemplateVarInFiles "${workingDir}" "{{datacenter}}" "${datacenter}"
+
+  
+
+}
+
+run "$@"

--- a/examples/devmode/fabio_docker.nomad
+++ b/examples/devmode/fabio_docker.nomad
@@ -1,0 +1,51 @@
+job "fabio" {
+  datacenters = ["{{datacenter}}"]
+
+  type = "system"
+
+  update {
+    stagger = "5s"
+    max_parallel = 1
+  }
+
+  group "fabio" {
+    task "fabio" {
+      driver = "docker"
+      config {
+        image = "fabiolb/fabio:latest"
+
+        port_map = {
+          http = 9999
+          ui   = 9998
+        }
+
+        volumes = [
+          "local/fabio.properties:/etc/fabio/fabio.properties"
+        ]
+      }
+
+      resources {
+        cpu = 500
+        memory = 128
+        network {
+          mbits = 1
+
+          port "http" {
+            static = 9999
+          }
+          port "ui" {
+            static = 9998
+          }
+        }
+      }
+
+      template {
+        data = <<EOH
+registry.consul.addr = {{host_ip_address}}:8500
+EOH
+        destination = "local/fabio.properties"
+        change_mode = "noop"
+      }
+    }
+  }
+}

--- a/examples/devmode/nomad.hcl
+++ b/examples/devmode/nomad.hcl
@@ -1,6 +1,6 @@
 log_level = "DEBUG"
 enable_debug = true
-datacenter = "testing"
+datacenter = "{{datacenter}}"
 data_dir = "/tmp/nomad-devagent"
 
 name = "nomad-devagent"
@@ -22,5 +22,5 @@ server {
 }
 
 consul {
-  address = "<host_ip_address>:8500"
+  address = "{{host_ip_address}}:8500"
 }

--- a/examples/devmode/registry/creg.nomad
+++ b/examples/devmode/registry/creg.nomad
@@ -1,5 +1,5 @@
 job "creg" {
-  datacenters = [ "testing" ]
+  datacenters = [ "{{datacenter}}" ]
   type = "service"
 
   update {


### PR DESCRIPTION
## Descriton
This MR adds a script for starting up the devmode locally.
* The parameters like {{host_ip_address}} and {{datacenter}} are adjusted automatically based on the script parameters.
* Those parameters are adjusted in the `nomad.hcl`, `consul.hcl` and in `creg.nomad` and `fabio_docker.nomad`.
* The job `fabio_docker.nomad` was added as well to have a complete, minimal dev setup.
* The original files in the repository are untouched when launching the script (since they are copied to a _temp_ dir).

## Hint
* The MR was NOT pulled from master, but from `f/devmode_advanced_enhanced` (was easier for now).