### PR TITLE
.Bugfix Docker home dir does not always exist, user-data will fail for ec2 instance creation if it does not, so make sure it does ahead of time...

### DIFF
--- a/modules/nomad-datacenter/user-data-nomad-client.sh
+++ b/modules/nomad-datacenter/user-data-nomad-client.sh
@@ -25,19 +25,23 @@ function log_info {
   log "INFO" "$message"
 }
 
-function configure_ecr_docker_credential_helper (){ 
+function configure_ecr_docker_credential_helper (){
   # These variables are passed in via Terraform template interplation
   log_info "Creating /etc/docker/config.json containing the credential helper for docker login to ECR"
   echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.${aws_region}.amazonaws.com\": \"ecr-login\"\n\t}\n}' > /etc/docker/config.json" | sudo sh
 
   log_info "Copy /etc/docker/config.json to /home/ec2-user/.docker/config.json"
+
+  # This directory does not always exist, so ensure it does
+  mkdir -p /home/ec2-user/.docker/
+
   cp /etc/docker/config.json /home/ec2-user/.docker/
   chown ec2-user /home/ec2-user/.docker/config.json
   chgrp ec2-user /home/ec2-user/.docker/config.json
 }
 
 
-function setup_consul_and_nomad (){ 
+function setup_consul_and_nomad (){
   # These variables are passed in via Terraform template interplation
   log_info "Configuring consul."
   /opt/consul/bin/run-consul --client --cluster-tag-key "${cluster_tag_key}" --cluster-tag-value "${cluster_tag_value}"

--- a/modules/nomad/user-data-nomad-server.sh
+++ b/modules/nomad/user-data-nomad-server.sh
@@ -25,18 +25,21 @@ function log_info {
   log "INFO" "$message"
 }
 
-function configure_ecr_docker_credential_helper (){ 
+function configure_ecr_docker_credential_helper (){
   # These variables are passed in via Terraform template interplation
   log_info "Creating /etc/docker/config.json containing the credential helper for docker login to ECR"
   echo -e "echo -e '{\n\"credHelpers\": {\n\t\"${aws_account_id}.dkr.ecr.${aws_region}.amazonaws.com\": \"ecr-login\"\n\t}\n}' > /etc/docker/config.json" | sudo sh
 
   log_info "Copy /etc/docker/config.json to /home/ec2-user/.docker/config.json"
+  # This directory does not always exist, so ensure it does
+  mkdir -p /home/ec2-user/.docker/
+
   cp /etc/docker/config.json /home/ec2-user/.docker/
   chown ec2-user /home/ec2-user/.docker/config.json
   chgrp ec2-user /home/ec2-user/.docker/config.json
 }
 
-function setup_consul_and_nomad (){ 
+function setup_consul_and_nomad (){
 
   # These variables are passed in via Terraform template interplation
   log_info "Configuring consul."


### PR DESCRIPTION
When booting from user-data, AWS will fail on instance creation, leaving you without available nomad/consul instances. 