### PR TITLE
Enable Authentication over ALB

### DIFF
--- a/examples/root-example/outputs.tf
+++ b/examples/root-example/outputs.tf
@@ -85,3 +85,51 @@ output "consul_servers_cluster_tag_key" {
 output "consul_servers_cluster_tag_value" {
   value = "${module.nomad-infra.consul_servers_cluster_tag_value}"
 }
+
+output "nomad_ui_alb_dns_name" {
+  value = "${module.nomad-infra.nomad_ui_alb_dns_name}"
+}
+
+output "nomad_ui_alb_https_targetgroup_arn" {
+  value = "${module.nomad-infra.nomad_ui_alb_https_targetgroup_arn}"
+}
+
+output "nomad_ui_alb_https_listener_arn" {
+  value = "${module.nomad-infra.nomad_ui_alb_https_listener_arn}"
+}
+
+output "consul_ui_alb_dns_name" {
+  value = "${module.nomad-infra.consul_ui_alb_dns_name}"
+}
+
+output "consul_ui_alb_https_targetgroup_arn" {
+  value = "${module.nomad-infra.consul_ui_alb_https_targetgroup_arn}"
+}
+
+output "consul_ui_alb_https_listener_arn" {
+  value = "${module.nomad-infra.consul_ui_alb_https_listener_arn}"
+}
+
+output "fabio_ui_alb_dns_name" {
+  value = "${module.nomad-infra.fabio_ui_alb_dns_name}"
+}
+
+output "fabio_ui_alb_https_targetgroup_arn" {
+  value = "${module.nomad-infra.fabio_ui_alb_https_targetgroup_arn}"
+}
+
+output "fabio_ui_alb_https_listener_arn" {
+  value = "${module.nomad-infra.fabio_ui_alb_https_listener_arn}"
+}
+
+output "dc-public-services_alb_https_targetgroup_arn" {
+  value = "${module.nomad-infra.dc-public-services_alb_https_targetgroup_arn}"
+}
+
+output "dc-private-services_alb_https_targetgroup_arn" {
+  value = "${module.nomad-infra.dc-private-services_alb_https_targetgroup_arn}"
+}
+
+output "dc-backoffice_alb_https_targetgroup_arn" {
+  value = "${module.nomad-infra.dc-backoffice_alb_https_targetgroup_arn}"
+}

--- a/modules/nomad-datacenter/outputs.tf
+++ b/modules/nomad-datacenter/outputs.tf
@@ -21,3 +21,7 @@ output "cluster_prefix" {
 output "sg_datacenter_id" {
   value = "${aws_security_group.sg_datacenter.id}"
 }
+
+output "alb_https_targetgroup_arn" {
+  value = "${aws_alb_target_group.tgr_ingress_controller.*.arn}"
+}

--- a/modules/ui-access/outputs.tf
+++ b/modules/ui-access/outputs.tf
@@ -1,35 +1,59 @@
-output "nomad_ui_alb_dns_name" {
-  value = "${aws_alb.alb_nomad_ui.dns_name}"
-}
-
-output "consul_ui_alb_dns_name" {
-  value = "${aws_alb.alb_consul_ui.dns_name}"
-}
-
-output "fabio_ui_alb_dns_name" {
-  value = "${aws_alb.alb_fabio_ui.dns_name}"
-}
-
 output "nomad_ui_alb_zone_id" {
   value = "${aws_alb.alb_nomad_ui.zone_id}"
-}
-
-output "consul_ui_alb_zone_id" {
-  value = "${aws_alb.alb_consul_ui.zone_id}"
-}
-
-output "fabio_ui_alb_zone_id" {
-  value = "${aws_alb.alb_fabio_ui.zone_id}"
 }
 
 output "nomad_ui_alb_sg_id" {
   value = "${aws_security_group.sg_ui_alb.id}"
 }
 
+output "nomad_ui_alb_dns_name" {
+  value = "${aws_alb.alb_nomad_ui.dns_name}"
+}
+
+output "nomad_ui_alb_https_targetgroup_arn" {
+  value = "${aws_alb_target_group.tgr_nomad_ui.arn}"
+}
+
+output "nomad_ui_alb_https_listener_arn" {
+  value = "${aws_alb_listener.albl_https_nomad_ui.*.arn}"
+}
+
+output "consul_ui_alb_zone_id" {
+  value = "${aws_alb.alb_consul_ui.zone_id}"
+}
+
 output "consul_ui_alb_sg_id" {
   value = "${aws_security_group.sg_ui_alb.id}"
 }
 
+output "consul_ui_alb_dns_name" {
+  value = "${aws_alb.alb_consul_ui.dns_name}"
+}
+
+output "consul_ui_alb_https_targetgroup_arn" {
+  value = "${aws_alb_target_group.tgr_consul_ui.arn}"
+}
+
+output "consul_ui_alb_https_listener_arn" {
+  value = "${aws_alb_listener.albl_https_consul_ui.*.arn}"
+}
+
+output "fabio_ui_alb_zone_id" {
+  value = "${aws_alb.alb_fabio_ui.zone_id}"
+}
+
 output "fabio_ui_alb_sg_id" {
   value = "${aws_security_group.sg_ui_alb.id}"
+}
+
+output "fabio_ui_alb_dns_name" {
+  value = "${aws_alb.alb_fabio_ui.dns_name}"
+}
+
+output "fabio_ui_alb_https_targetgroup_arn" {
+  value = "${aws_alb_target_group.tgr_fabio_ui.arn}"
+}
+
+output "fabio_ui_alb_https_listener_arn" {
+  value = "${aws_alb_listener.albl_https_fabio_ui.*.arn}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -58,12 +58,24 @@ output "dc-public-services_sg_id" {
   value = "${module.dc-public-services.sg_datacenter_id}"
 }
 
+output "dc-public-services_alb_https_targetgroup_arn" {
+  value = "${module.dc-public-services.alb_https_targetgroup_arn}"
+}
+
 output "dc-private-services_sg_id" {
   value = "${module.dc-private-services.sg_datacenter_id}"
 }
 
+output "dc-private-services_alb_https_targetgroup_arn" {
+  value = "${module.dc-private-services.alb_https_targetgroup_arn}"
+}
+
 output "dc-backoffice_sg_id" {
   value = "${module.dc-backoffice.sg_datacenter_id}"
+}
+
+output "dc-backoffice_alb_https_targetgroup_arn" {
+  value = "${module.dc-backoffice.alb_https_targetgroup_arn}"
 }
 
 output "consul_servers_sg_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,12 +22,36 @@ output "nomad_ui_alb_dns_name" {
   value = "${module.ui-access.nomad_ui_alb_dns_name}"
 }
 
+output "nomad_ui_alb_https_targetgroup_arn" {
+  value = "${module.ui-access.nomad_ui_alb_https_targetgroup_arn}"
+}
+
+output "nomad_ui_alb_https_listener_arn" {
+  value = "${module.ui-access.nomad_ui_alb_https_listener_arn}"
+}
+
 output "consul_ui_alb_dns_name" {
   value = "${module.ui-access.consul_ui_alb_dns_name}"
 }
 
+output "consul_ui_alb_https_targetgroup_arn" {
+  value = "${module.ui-access.consul_ui_alb_https_targetgroup_arn}"
+}
+
+output "consul_ui_alb_https_listener_arn" {
+  value = "${module.ui-access.consul_ui_alb_https_listener_arn}"
+}
+
 output "fabio_ui_alb_dns_name" {
   value = "${module.ui-access.fabio_ui_alb_dns_name}"
+}
+
+output "fabio_ui_alb_https_targetgroup_arn" {
+  value = "${module.ui-access.fabio_ui_alb_https_targetgroup_arn}"
+}
+
+output "fabio_ui_alb_https_listener_arn" {
+  value = "${module.ui-access.fabio_ui_alb_https_listener_arn}"
 }
 
 output "nomad_ui_alb_zone_id" {


### PR DESCRIPTION
AWS ALB's support the feature of using identity-providers like OneLogin for authenticating incoming requests.
In order to enable this feature an ALB listener rule has to be added that takes all requests redirecting them to the identity provider for validation and then forwards authenticated requests to the according target-group.

To be able to use this functionality for the cos, the cos has to provide the needed information (as output) to create such a listener rule.

Needed outputs are:
1. The DNS name of the ALB (already available)
2. The ARN of the https listener attached to the ALB
3. The ARN of the target group the listener routes requests to